### PR TITLE
Add POSIX::Spawn method for extra point of reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 gem 'rake-compiler'
 gem 'minitest'
+
+group :test do
+  gem 'posix-spawn', require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     minitest (4.7.5)
+    posix-spawn (0.3.6)
     rake (10.1.0)
     rake-compiler (0.8.3)
       rake
@@ -11,5 +12,6 @@ PLATFORMS
 
 DEPENDENCIES
   minitest
+  posix-spawn
   rake
   rake-compiler

--- a/spec/benchmark_spec.rb
+++ b/spec/benchmark_spec.rb
@@ -20,4 +20,18 @@ describe "Process information retrieval" do
   bench_performance_constant "Spawn_ps_rss", 0.9 do
     `ps -o rss= -p #{Process.pid}`.to_i
   end
+
+  bench_performance_constant "POSIX::Spawn.popen4" do
+    begin
+      require 'posix/spawn'
+      pid, stdin, stdout, stderr = POSIX::Spawn.popen4('ps', "-o rss= -p #{Process.pid}")
+      stdin.close
+      rss = stdout.read.to_i
+    rescue => e
+      # nothing right now.
+    ensure 
+      [stdin, stdout, stderr].each { |fd| fd.close unless fd.closed? }
+      stat = Process::waitpid(pid)
+    end
+  end
 end


### PR DESCRIPTION
Here is new output for benchmark tests:

```
# Running benchmarks:


Process information retrieval            1              10             100            1000           10000
+bench_POSIX_Spawn_popen4         0.005980        0.025996        0.004227        0.002901        0.002780
bench_Process_stats               0.000048        0.000041        0.000034        0.000035        0.000036
bench_Process_stats_children      0.000042        0.000038        0.000034        0.000031        0.000032
bench_Process_stats_self          0.000048        0.000046        0.000032        0.000033        0.000035
bench_Spawn_ps_rss                0.050123        0.020579        0.043924        0.058219        0.064938
bench_System_uname                0.000042        0.000031        0.000027        0.000027        0.000026


Finished benchmarks in 0.673457s, 8.9093 tests/s, 8.9093 assertions/s.

6 tests, 6 assertions, 0 failures, 0 errors, 0 skips
```
