### PR TITLE
Move require outside of benchmark method for fairness

### DIFF
--- a/spec/benchmark_spec.rb
+++ b/spec/benchmark_spec.rb
@@ -1,4 +1,5 @@
 require "minitest/benchmark"
+require 'posix/spawn'
 
 describe "Process information retrieval" do
   bench_performance_constant "System.uname" do
@@ -23,7 +24,6 @@ describe "Process information retrieval" do
 
   bench_performance_constant "POSIX::Spawn.popen4" do
     begin
-      require 'posix/spawn'
       pid, stdin, stdout, stderr = POSIX::Spawn.popen4('ps', "-o rss= -p #{Process.pid}")
       stdin.close
       rss = stdout.read.to_i


### PR DESCRIPTION
```
# Running benchmarks:

Process information retrieval   1   10  100 1000    10000
bench_POSIX_Spawn_popen4     0.002088    0.001913    0.001926    0.001812    0.001770
bench_Process_stats  0.000034    0.000037    0.000036    0.000031    0.000028
bench_Process_stats_children     0.000041    0.000033    0.000033    0.000037    0.000035
bench_Process_stats_self     0.000046    0.000040    0.000035    0.000034    0.000036
bench_Spawn_ps_rss   0.009240    0.008660    0.012322    0.010561    0.007450
bench_System_uname   0.000038    0.000018    0.000012    0.000011    0.000011
Finished benchmarks in 0.273769s, 21.9163 tests/s, 21.9163 assertions/s.
6 tests, 6 assertions, 0 failures, 0 errors, 0 skips
```
